### PR TITLE
Fix purchase order filtering by client

### DIFF
--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/repository/PurchaseOrderRepository.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/repository/PurchaseOrderRepository.java
@@ -3,7 +3,10 @@ package grupo5.gestion_inventario.clientpanel.repository;
 import grupo5.gestion_inventario.clientpanel.model.PurchaseOrder;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import java.util.List;
 
 @Repository
 public interface PurchaseOrderRepository extends JpaRepository<PurchaseOrder, Long> {
+    // Permite obtener las órdenes de compra asociadas a un cliente específico
+    List<PurchaseOrder> findByClientId(Long clientId);
 }

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/controller/PurchaseOrderController.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/controller/PurchaseOrderController.java
@@ -11,33 +11,33 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/purchase-orders")
+@RequestMapping("/api")
 @CrossOrigin(origins = "http://localhost:5173") // Permitir peticiones desde el frontend de React
 public class PurchaseOrderController {
 
     @Autowired
     private PurchaseOrderService purchaseOrderService;
 
-    @GetMapping
-    public ResponseEntity<List<PurchaseOrder>> getAllPurchaseOrders() {
-        List<PurchaseOrder> purchaseOrders = purchaseOrderService.getAllPurchaseOrders();
+    @GetMapping("/clients/{clientId}/purchase-orders")
+    public ResponseEntity<List<PurchaseOrder>> getAllPurchaseOrders(@PathVariable Long clientId) {
+        List<PurchaseOrder> purchaseOrders = purchaseOrderService.getAllPurchaseOrders(clientId);
         return ResponseEntity.ok(purchaseOrders);
     }
 
-    @GetMapping("/{id}")
+    @GetMapping("/purchase-orders/{id}")
     public ResponseEntity<PurchaseOrder> getPurchaseOrderById(@PathVariable Long id) {
         return purchaseOrderService.getPurchaseOrderById(id)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
     }
 
-    @PostMapping
+    @PostMapping("/purchase-orders")
     public ResponseEntity<PurchaseOrder> createPurchaseOrder(@RequestBody PurchaseOrderRequest request) {
         PurchaseOrder newPurchaseOrder = purchaseOrderService.createPurchaseOrder(request);
         return new ResponseEntity<>(newPurchaseOrder, HttpStatus.CREATED);
     }
 
-    @PostMapping("/{id}/receive")
+    @PostMapping("/purchase-orders/{id}/receive")
     public ResponseEntity<PurchaseOrder> receivePurchaseOrder(@PathVariable Long id) {
         PurchaseOrder updatedPurchaseOrder = purchaseOrderService.receivePurchaseOrder(id);
         return ResponseEntity.ok(updatedPurchaseOrder);

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/service/PurchaseOrderService.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/service/PurchaseOrderService.java
@@ -43,8 +43,8 @@ public class PurchaseOrderService {
     private StockMovementRepository stockMovementRepository;
 
     @Transactional(readOnly = true)
-    public List<PurchaseOrder> getAllPurchaseOrders() {
-        return purchaseOrderRepository.findAll();
+    public List<PurchaseOrder> getAllPurchaseOrders(Long clientId) {
+        return purchaseOrderRepository.findByClientId(clientId);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## Summary
- restrict purchase orders by client
- expose new REST endpoint `/api/clients/{clientId}/purchase-orders`

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68462b044830832b85a826f632c5036d