### PR TITLE
Add basic role support

### DIFF
--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/dto/AuthResponse.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/dto/AuthResponse.java
@@ -4,6 +4,13 @@ package grupo5.gestion_inventario.clientpanel.dto;
 
 public class AuthResponse {
     private String token;
-    public AuthResponse(String token) { this.token = token; }
+    private String role;
+
+    public AuthResponse(String token, String role) {
+        this.token = token;
+        this.role = role;
+    }
+
     public String getToken() { return token; }
+    public String getRole() { return role; }
 }

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/controller/AuthController.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/controller/AuthController.java
@@ -57,6 +57,7 @@ public class AuthController {
 
         String username = authentication.getName();
         String token;
+        String role = roles.isEmpty() ? null : roles.get(0).replace("ROLE_", "");
 
         // 3) Si es ROLE_CLIENT, busco el clientId y uso generateToken con clientId
         if (roles.contains("ROLE_CLIENT")) {
@@ -71,6 +72,6 @@ public class AuthController {
             token = jwtUtil.generateToken(username, roles);
         }
 
-        return new AuthResponse(token);
+        return new AuthResponse(token, role);
     }
 }

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/controller/ProductController.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/controller/ProductController.java
@@ -6,6 +6,7 @@ import grupo5.gestion_inventario.model.Client;
 import grupo5.gestion_inventario.repository.ClientRepository;
 import grupo5.gestion_inventario.service.ProductService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
@@ -13,6 +14,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/client/products")
+@PreAuthorize("hasAuthority('ADMIN')")
 public class ProductController {
 
     private final ProductService   productService;

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/model/Client.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/model/Client.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import org.hibernate.annotations.CreationTimestamp;
 
+import grupo5.gestion_inventario.model.Role;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -24,6 +26,10 @@ public class Client {
 
     @Column(nullable = false)
     private String passwordHash;                // SIEMPRE BCrypt
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
 
     /* -------- info extra -------- */
     private String telefono;
@@ -49,6 +55,9 @@ public class Client {
 
     public String getPasswordHash()  { return passwordHash; }
     public void   setPasswordHash(String p) { this.passwordHash = p; }
+
+    public Role getRole() { return role; }
+    public void setRole(Role role) { this.role = role; }
 
     public String getTelefono()      { return telefono; }
     public void   setTelefono(String t){ this.telefono = t; }

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/model/Role.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/model/Role.java
@@ -1,0 +1,6 @@
+package grupo5.gestion_inventario.model;
+
+public enum Role {
+    ADMIN,
+    CASHIER
+}

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/security/CustomUserDetailsService.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/security/CustomUserDetailsService.java
@@ -1,6 +1,7 @@
 package grupo5.gestion_inventario.security;
 
 import grupo5.gestion_inventario.model.Client;
+import grupo5.gestion_inventario.model.Role;
 import grupo5.gestion_inventario.repository.ClientRepository;
 import grupo5.gestion_inventario.superpanel.model.AdminUser;
 import grupo5.gestion_inventario.superpanel.repository.AdminUserRepository;
@@ -44,10 +45,11 @@ public class CustomUserDetailsService implements UserDetailsService {
                         .orElse(null));
 
         if (client != null) {
+            String role = client.getRole() != null ? client.getRole().name() : "CLIENT";
             return User.builder()
                     .username(client.getEmail())      // clave del JWT
                     .password(client.getPasswordHash())
-                    .roles("CLIENT")
+                    .roles(role)
                     .build();
         }
 

--- a/gestion-inventario-frontend/src/components/client/EmployeesSection.jsx
+++ b/gestion-inventario-frontend/src/components/client/EmployeesSection.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function EmployeesSection() {
+    return (
+        <div>
+            <h2>Gestión de Empleados</h2>
+            <p>Aquí podrás crear y administrar empleados.</p>
+        </div>
+    );
+}
+
+export default EmployeesSection;

--- a/gestion-inventario-frontend/src/pages/ClientPanelPage.jsx
+++ b/gestion-inventario-frontend/src/pages/ClientPanelPage.jsx
@@ -7,10 +7,12 @@ import SalesSection from '../components/client/SalesSection';
 import ProvidersSection from '../components/client/ProvidersSection';
 import PurchasesSection from '../components/client/PurchasesSection';
 import CustomersSection from '../components/client/CustomersSection';
+import EmployeesSection from '../components/client/EmployeesSection';
 
 function ClientPanelPage() {
     const navigate = useNavigate();
     const location = useLocation(); // Hook para leer la info de la URL actual
+    const role = localStorage.getItem('role');
 
     // La sección activa ahora se determina por el HASH de la URL, o es 'dashboard' por defecto
     const [activeSection, setActiveSection] = useState(location.hash.replace('#', '') || 'dashboard');
@@ -25,6 +27,7 @@ function ClientPanelPage() {
     const handleLogout = () => {
         localStorage.removeItem('jwt');
         localStorage.removeItem('clientId');
+        localStorage.removeItem('role');
         navigate('/login');
     };
 
@@ -45,6 +48,8 @@ function ClientPanelPage() {
                 return <CustomersSection />;
             case 'proveedores':
                 return <ProvidersSection />;
+            case 'empleados':
+                return <EmployeesSection />;
             case 'dashboard':
             default:
                 return <DashboardSection />;
@@ -58,11 +63,16 @@ function ClientPanelPage() {
                 <nav>
                     {/* Los botones ahora llaman a handleSectionChange para actualizar la URL */}
                     <button onClick={() => handleSectionChange('dashboard')}>Dashboard</button>
-                    <button onClick={() => handleSectionChange('inventario')}>Inventario</button>
+                    {role === 'ADMIN' && (
+                        <>
+                            <button onClick={() => handleSectionChange('inventario')}>Inventario</button>
+                            <button onClick={() => handleSectionChange('compras')}>Compras</button>
+                            <button onClick={() => handleSectionChange('proveedores')}>Proveedores</button>
+                            <button onClick={() => handleSectionChange('empleados')}>Empleados</button>
+                        </>
+                    )}
                     <button onClick={() => handleSectionChange('ventas')}>Ventas</button>
-                    <button onClick={() => handleSectionChange('compras')}>Compras</button>
                     <button onClick={() => handleSectionChange('clientes')}>Clientes</button>
-                    <button onClick={() => handleSectionChange('proveedores')}>Proveedores</button>
                     <button id="logout-btn" onClick={handleLogout}>Cerrar sesión</button>
                 </nav>
             </header>

--- a/gestion-inventario-frontend/src/pages/LoginPage.jsx
+++ b/gestion-inventario-frontend/src/pages/LoginPage.jsx
@@ -16,21 +16,23 @@ function LoginPage() {
         try {
             // Usamos nuestro cliente API para hacer la petición POST
             const response = await api.post('/auth/login', { username, password });
-            const { token } = response;
+            const { token, role } = response;
 
             if (!token) {
                 throw new Error('No se recibió un token del servidor.');
             }
 
-            // Guardamos el JWT en el almacenamiento local
+            // Guardamos el JWT y el rol en el almacenamiento local
             localStorage.setItem('jwt', token);
+            if (role) {
+                localStorage.setItem('role', role);
+            }
 
-            // Decodificamos el token para obtener los roles y el clientId
+            // Decodificamos el token para obtener el clientId
             const [, payloadB64] = token.split('.');
             const padded = payloadB64.replace(/-/g, '+').replace(/_/g, '/') + '=='.slice(0, (4 - payloadB64.length % 4) % 4);
             const decoded = JSON.parse(atob(padded));
 
-            const roles = decoded.roles || [];
             const clientId = decoded.clientId;
 
             // Guardamos el clientId si existe
@@ -39,9 +41,9 @@ function LoginPage() {
             }
 
             // Redirigimos según el rol del usuario
-            if (roles.includes('ROLE_ADMIN')) {
+            if (role === 'ADMIN') {
                 navigate('/panel-admin');
-            } else if (roles.includes('ROLE_CLIENT')) {
+            } else if (role === 'CASHIER' || role === 'ADMIN') {
                 navigate('/panel-cliente');
             } else {
                 setError('Su cuenta no tiene un rol válido.');


### PR DESCRIPTION
## Summary
- include `role` in `AuthResponse` and client entity
- send the user role on login
- store role in frontend and hide admin sections for CASHIER
- add Employees section placeholder
- restrict product endpoints to ADMIN only

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*
- `npm test` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_68463a3650e4832bb4e8a4f082331758