### PR TITLE
Add employee roles with basic management

### DIFF
--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/dto/AuthResponse.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/dto/AuthResponse.java
@@ -4,6 +4,13 @@ package grupo5.gestion_inventario.clientpanel.dto;
 
 public class AuthResponse {
     private String token;
-    public AuthResponse(String token) { this.token = token; }
+    private String role;
+
+    public AuthResponse(String token, String role) {
+        this.token = token;
+        this.role = role;
+    }
+
     public String getToken() { return token; }
+    public String getRole() { return role; }
 }

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/dto/EmployeeRequest.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/dto/EmployeeRequest.java
@@ -1,0 +1,24 @@
+package grupo5.gestion_inventario.clientpanel.dto;
+
+import grupo5.gestion_inventario.model.Role;
+
+public class EmployeeRequest {
+    private String name;
+    private String email;
+    private String password;
+    private Role role;
+
+    public EmployeeRequest() {}
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+
+    public String getPassword() { return password; }
+    public void setPassword(String password) { this.password = password; }
+
+    public Role getRole() { return role; }
+    public void setRole(Role role) { this.role = role; }
+}

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/model/CashRegisterSession.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/model/CashRegisterSession.java
@@ -1,7 +1,7 @@
 // src/main/java/grupo5/gestion_inventario/clientpanel/model/CashRegisterSession.java
 package grupo5.gestion_inventario.clientpanel.model;
 
-import grupo5.gestion_inventario.model.Client;
+import grupo5.gestion_inventario.model.Employee;
 import jakarta.persistence.*;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -32,7 +32,7 @@ public class CashRegisterSession {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "client_id", nullable = false)
-    private Client client;
+    private Employee client;
 
     /** Constructor por defecto: establece openedAt = ahora */
     public CashRegisterSession() {
@@ -42,7 +42,7 @@ public class CashRegisterSession {
     /**
      * Constructor completo (cierre se asigna luego).
      */
-    public CashRegisterSession(BigDecimal openingBalance, Client client) {
+    public CashRegisterSession(BigDecimal openingBalance, Employee client) {
         this.openingBalance = openingBalance;
         this.client = client;
         this.openedAt = LocalDateTime.now();
@@ -82,10 +82,10 @@ public class CashRegisterSession {
         this.closedAt = closedAt;
     }
 
-    public Client getClient() {
+    public Employee getClient() {
         return client;
     }
-    public void setClient(Client client) {
+    public void setClient(Employee client) {
         this.client = client;
     }
 }

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/model/Compra.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/model/Compra.java
@@ -1,7 +1,7 @@
 package grupo5.gestion_inventario.clientpanel.model;
 
 import com.fasterxml.jackson.annotation.JsonManagedReference;
-import grupo5.gestion_inventario.model.Client;
+import grupo5.gestion_inventario.model.Employee;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -21,7 +21,7 @@ public class Compra {
 
     @ManyToOne
     @JoinColumn(name = "id_cliente", nullable = false)
-    private Client client;
+    private Employee client;
 
     @ManyToOne
     @JoinColumn(name = "id_proveedor", nullable = false)
@@ -57,11 +57,11 @@ public class Compra {
         this.total = total;
     }
 
-    public Client getClient() {
+    public Employee getClient() {
         return client;
     }
 
-    public void setClient(Client client) {
+    public void setClient(Employee client) {
         this.client = client;
     }
 

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/model/EndCustomer.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/model/EndCustomer.java
@@ -1,6 +1,6 @@
 package grupo5.gestion_inventario.clientpanel.model;
 
-import grupo5.gestion_inventario.model.Client;
+import grupo5.gestion_inventario.model.Employee;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 
@@ -22,11 +22,11 @@ public class EndCustomer {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "client_id", nullable = false)
-    private Client client;
+    private Employee client;
 
     public EndCustomer() {}
 
-    public EndCustomer(String name, String contactInfo, Client client) {
+    public EndCustomer(String name, String contactInfo, Employee client) {
         this.name = name;
         this.contactInfo = contactInfo;
         this.client = client;
@@ -38,6 +38,6 @@ public class EndCustomer {
     public String getContactInfo() { return contactInfo; }
     public void setContactInfo(String contactInfo) { this.contactInfo = contactInfo; }
     public LocalDateTime getCreatedAt() { return createdAt; }
-    public Client getClient() { return client; }
-    public void setClient(Client client) { this.client = client; }
+    public Employee getClient() { return client; }
+    public void setClient(Employee client) { this.client = client; }
 }

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/model/Expense.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/model/Expense.java
@@ -2,7 +2,7 @@
 package grupo5.gestion_inventario.clientpanel.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import grupo5.gestion_inventario.model.Client;
+import grupo5.gestion_inventario.model.Employee;
 import jakarta.persistence.*;
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -34,7 +34,7 @@ public class Expense {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "client_id", nullable = false)
     @JsonIgnore
-    private Client client;
+    private Employee client;
 
     /** Constructor por defecto */
     public Expense() {}
@@ -51,7 +51,7 @@ public class Expense {
                    BigDecimal amount,
                    String type,
                    LocalDate date,
-                   Client client) {
+                   Employee client) {
         this.description = description;
         this.amount      = amount;
         this.type        = type;
@@ -93,10 +93,10 @@ public class Expense {
         this.date = date;
     }
 
-    public Client getClient() {
+    public Employee getClient() {
         return client;
     }
-    public void setClient(Client client) {
+    public void setClient(Employee client) {
         this.client = client;
     }
 }

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/model/Provider.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/model/Provider.java
@@ -1,7 +1,7 @@
 // src/main/java/grupo5/gestion_inventario/clientpanel/model/Provider.java
 package grupo5.gestion_inventario.clientpanel.model;
 
-import grupo5.gestion_inventario.model.Client;
+import grupo5.gestion_inventario.model.Employee;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 
@@ -31,7 +31,7 @@ public class Provider {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "client_id", nullable = false)
-    private Client client;
+    private Employee client;
 
     /** Constructor por defecto */
     public Provider() {}
@@ -46,7 +46,7 @@ public class Provider {
     public Provider(String name,
                     String contactInfo,
                     String paymentTerms,
-                    Client client) {
+                    Employee client) {
         this.name         = name;
         this.contactInfo  = contactInfo;
         this.paymentTerms = paymentTerms;
@@ -88,10 +88,10 @@ public class Provider {
         this.createdAt = createdAt;
     }
 
-    public Client getClient() {
+    public Employee getClient() {
         return client;
     }
-    public void setClient(Client client) {
+    public void setClient(Employee client) {
         this.client = client;
     }
 }

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/model/PurchaseOrder.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/model/PurchaseOrder.java
@@ -1,6 +1,6 @@
 package grupo5.gestion_inventario.clientpanel.model;
 
-import grupo5.gestion_inventario.model.Client;
+import grupo5.gestion_inventario.model.Employee;
 import jakarta.persistence.*;
 import java.math.BigDecimal;
 import java.util.Date;
@@ -27,7 +27,7 @@ public class PurchaseOrder {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "client_id", nullable = false)
-    private Client client;
+    private Employee client;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -85,11 +85,11 @@ public class PurchaseOrder {
         this.provider = provider;
     }
 
-    public Client getClient() {
+    public Employee getClient() {
         return client;
     }
 
-    public void setClient(Client client) {
+    public void setClient(Employee client) {
         this.client = client;
     }
 

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/model/Sale.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/model/Sale.java
@@ -1,7 +1,7 @@
 package grupo5.gestion_inventario.clientpanel.model;
 
 import com.fasterxml.jackson.annotation.JsonManagedReference;
-import grupo5.gestion_inventario.model.Client;
+import grupo5.gestion_inventario.model.Employee;
 import grupo5.gestion_inventario.clientpanel.model.EndCustomer;
 import jakarta.persistence.*;
 import java.math.BigDecimal;
@@ -28,7 +28,7 @@ public class Sale {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "client_id", nullable = false)
-    private Client client;
+    private Employee client;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "end_customer_id")
@@ -53,7 +53,7 @@ public class Sale {
      */
     public Sale(String paymentMethod,
                 BigDecimal totalAmount,
-                Client client,
+                Employee client,
                 EndCustomer endCustomer,
                 List<SaleItem> items,
                 LocalDateTime saleDate) { // <-- PARÁMETRO AÑADIDO
@@ -80,8 +80,8 @@ public class Sale {
     public BigDecimal getTotalAmount()      { return totalAmount; }
     public void setTotalAmount(BigDecimal totalAmount) { this.totalAmount = totalAmount; }
 
-    public Client getClient()               { return client; }
-    public void setClient(Client client)    { this.client = client; }
+    public Employee getClient()               { return client; }
+    public void setClient(Employee client)    { this.client = client; }
 
     public EndCustomer getEndCustomer() { return endCustomer; }
     public void setEndCustomer(EndCustomer endCustomer) { this.endCustomer = endCustomer; }
@@ -125,7 +125,7 @@ public class Sale {
      * @param paymentMethod El método de pago.
      * @param saleDate La fecha de la venta (puede ser nula, en cuyo caso se usa la actual).
      */
-    public Sale(Client client, EndCustomer endCustomer, String paymentMethod, LocalDateTime saleDate) {
+    public Sale(Employee client, EndCustomer endCustomer, String paymentMethod, LocalDateTime saleDate) {
         this.client = client;
         this.endCustomer = endCustomer;
         this.paymentMethod = paymentMethod;

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/config/SecurityConfig.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/config/SecurityConfig.java
@@ -83,7 +83,7 @@ public class SecurityConfig {
                                 "/", "/index.html", "/login.html")
                         .permitAll()
                         .requestMatchers("/admin/**").hasRole("ADMIN")
-                        .requestMatchers("/client/**").hasRole("CLIENT")
+                        .requestMatchers("/client/**").hasAnyRole("ADMIN", "CASHIER")
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtFilter,

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/controller/AdminClientController.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/controller/AdminClientController.java
@@ -3,8 +3,8 @@ package grupo5.gestion_inventario.controller;
 import grupo5.gestion_inventario.clientpanel.dto.ClientCreateRequest;
 import grupo5.gestion_inventario.clientpanel.dto.ClientListDto;
 import grupo5.gestion_inventario.clientpanel.dto.ClientRowDto;
-import grupo5.gestion_inventario.model.Client;
-import grupo5.gestion_inventario.service.ClientService;
+import grupo5.gestion_inventario.model.Employee;
+import grupo5.gestion_inventario.service.EmployeeService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -18,10 +18,10 @@ import java.util.List;
 @PreAuthorize("hasRole('ADMIN')")
 public class AdminClientController {
 
-    private final ClientService    clientService;
+    private final EmployeeService    clientService;
     private final PasswordEncoder  passwordEncoder;
 
-    public AdminClientController(ClientService clientService,
+    public AdminClientController(EmployeeService clientService,
                                  PasswordEncoder passwordEncoder) {
         this.clientService   = clientService;
         this.passwordEncoder = passwordEncoder;
@@ -32,7 +32,7 @@ public class AdminClientController {
      */
     @PostMapping
     public ResponseEntity<ClientRowDto> createClient(@RequestBody ClientCreateRequest req) {
-        Client client = new Client();
+        Employee client = new Employee();
         client.setName(      req.getName() );
         client.setEmail(     req.getEmail() );
         client.setPasswordHash(passwordEncoder.encode(req.getPassword()));
@@ -40,7 +40,7 @@ public class AdminClientController {
         client.setPlan(      req.getPlan().toUpperCase());
         client.setEstado(    req.getEstado().toUpperCase());
 
-        Client saved = clientService.create(client);
+        Employee saved = clientService.create(client);
 
         ClientRowDto dto = new ClientRowDto(
                 saved.getId(),

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/controller/ClientController.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/controller/ClientController.java
@@ -1,8 +1,8 @@
 /*package grupo5.gestion_inventario.controller;
 
 import grupo5.gestion_inventario.clientpanel.dto.ClientCreateRequest;
-import grupo5.gestion_inventario.model.Client;
-import grupo5.gestion_inventario.repository.ClientRepository;
+import grupo5.gestion_inventario.model.Employee;
+import grupo5.gestion_inventario.repository.EmployeeRepository;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -15,20 +15,20 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/admin/clients")
 public class ClientController {
 
-    private final ClientRepository   clientRepo;
+    private final EmployeeRepository   employeeRepo;
     private final PasswordEncoder    passwordEncoder;
 
-    public ClientController(ClientRepository clientRepo,
+    public ClientController(EmployeeRepository employeeRepo,
                             PasswordEncoder passwordEncoder) {
-        this.clientRepo      = clientRepo;
+        this.employeeRepo      = employeeRepo;
         this.passwordEncoder = passwordEncoder;
     }
 
     @PostMapping
     @PreAuthorize("hasRole('ADMIN')")
-    public ResponseEntity<Client> create(@RequestBody ClientCreateRequest req) {
+    public ResponseEntity<Employee> create(@RequestBody ClientCreateRequest req) {
         // 1) Construimos la entidad usando los campos correctos
-        Client c = new Client();
+        Employee c = new Employee();
         c.setName(req.getName());
         c.setEmail(req.getEmail());
         // ── Hasheamos en BCrypt y guardamos en passwordHash ──
@@ -39,7 +39,7 @@ public class ClientController {
         c.setEstado(req.getEstado().toUpperCase());
 
         // 2) Persistimos
-        Client saved = clientRepo.save(c);
+        Employee saved = employeeRepo.save(c);
 
         // 3) Respondemos con CREATED
         return ResponseEntity

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/controller/ClientDashboardController.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/controller/ClientDashboardController.java
@@ -5,8 +5,8 @@ import grupo5.gestion_inventario.clientpanel.dto.ProductDto;
 import grupo5.gestion_inventario.clientpanel.dto.ProfitabilitySummaryDto;
 import grupo5.gestion_inventario.clientpanel.dto.SaleDto;
 import grupo5.gestion_inventario.clientpanel.dto.SalesDailySummaryDto; // <-- IMPORT AÑADIDO
-import grupo5.gestion_inventario.model.Client;
-import grupo5.gestion_inventario.repository.ClientRepository;
+import grupo5.gestion_inventario.model.Employee;
+import grupo5.gestion_inventario.repository.EmployeeRepository;
 import grupo5.gestion_inventario.service.ProductService;
 import grupo5.gestion_inventario.service.SalesService;
 import org.springframework.http.ResponseEntity;
@@ -18,25 +18,25 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/client")
-@PreAuthorize("hasRole('CLIENT')")
+@PreAuthorize("hasAnyAuthority('ADMIN','CASHIER')")
 public class ClientDashboardController {
 
-    private final ClientRepository clientRepo;
+    private final EmployeeRepository employeeRepo;
     private final ProductService   productService;
     private final SalesService     salesService;
 
     public ClientDashboardController(
-            ClientRepository clientRepo,
+            EmployeeRepository employeeRepo,
             ProductService productService,
             SalesService salesService) {
-        this.clientRepo     = clientRepo;
+        this.employeeRepo     = employeeRepo;
         this.productService = productService;
         this.salesService   = salesService;
     }
 
     @GetMapping("/dashboard")
     public ResponseEntity<ClientDashboardDto> dashboard(Authentication auth) {
-        Client client = clientRepo.findByEmail(auth.getName())
+        Employee client = employeeRepo.findByEmail(auth.getName())
                 .orElseThrow(() -> new RuntimeException("Cliente no encontrado"));
 
         long lowStock   = productService.countLowStock(client.getId());
@@ -50,7 +50,7 @@ public class ClientDashboardController {
     public ResponseEntity<List<ProfitabilitySummaryDto>> getProfitabilitySummary(
             @RequestParam(defaultValue = "30") int days,
             Authentication auth) {
-        Client client = clientRepo.findByEmail(auth.getName())
+        Employee client = employeeRepo.findByEmail(auth.getName())
                 .orElseThrow(() -> new RuntimeException("Cliente no encontrado"));
 
         List<ProfitabilitySummaryDto> summary = salesService.getProfitabilitySummaryLastDays(client.getId(), days);
@@ -66,7 +66,7 @@ public class ClientDashboardController {
     public ResponseEntity<List<SalesDailySummaryDto>> getSalesSummary(
             @RequestParam(defaultValue = "30") int days,
             Authentication auth) {
-        Client client = clientRepo.findByEmail(auth.getName())
+        Employee client = employeeRepo.findByEmail(auth.getName())
                 .orElseThrow(() -> new RuntimeException("Cliente no encontrado"));
 
         List<SalesDailySummaryDto> summary = salesService.summaryLastDays(client.getId(), days);
@@ -76,7 +76,7 @@ public class ClientDashboardController {
 
     @GetMapping("/items")
     public ResponseEntity<List<ProductDto>> items(Authentication auth) {
-        Client client = clientRepo.findByEmail(auth.getName())
+        Employee client = employeeRepo.findByEmail(auth.getName())
                 .orElseThrow(() -> new RuntimeException("Cliente no encontrado"));
 
         List<ProductDto> products = productService.findByClientId(client.getId());
@@ -85,7 +85,7 @@ public class ClientDashboardController {
 
     @GetMapping("/sales")
     public ResponseEntity<List<SaleDto>> sales(Authentication auth) {
-        Client client = clientRepo.findByEmail(auth.getName())
+        Employee client = employeeRepo.findByEmail(auth.getName())
                 .orElseThrow(() -> new RuntimeException("Cliente no encontrado"));
 
         List<SaleDto> sales = salesService.findByClientId(client.getId());

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/controller/ClientEndCustomerController.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/controller/ClientEndCustomerController.java
@@ -1,8 +1,8 @@
 package grupo5.gestion_inventario.controller;
 
 import grupo5.gestion_inventario.clientpanel.model.EndCustomer;
-import grupo5.gestion_inventario.model.Client;
-import grupo5.gestion_inventario.repository.ClientRepository;
+import grupo5.gestion_inventario.model.Employee;
+import grupo5.gestion_inventario.repository.EmployeeRepository;
 import grupo5.gestion_inventario.service.EndCustomerService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,34 +15,34 @@ import java.util.List;
 @RequestMapping("/client/end-customers")
 public class ClientEndCustomerController {
     private final EndCustomerService service;
-    private final ClientRepository clientRepo;
+    private final EmployeeRepository employeeRepo;
 
-    public ClientEndCustomerController(EndCustomerService service, ClientRepository clientRepo) {
+    public ClientEndCustomerController(EndCustomerService service, EmployeeRepository employeeRepo) {
         this.service = service;
-        this.clientRepo = clientRepo;
+        this.employeeRepo = employeeRepo;
     }
 
-    private Client getAuthClient(Authentication auth) {
-        return clientRepo.findByEmail(auth.getName())
+    private Employee getAuthClient(Authentication auth) {
+        return employeeRepo.findByEmail(auth.getName())
                 .orElseThrow(() -> new IllegalArgumentException("Cliente no encontrado"));
     }
 
     @GetMapping
     public ResponseEntity<List<EndCustomer>> list(Authentication auth) {
-        Client client = getAuthClient(auth);
+        Employee client = getAuthClient(auth);
         return ResponseEntity.ok(service.listByClient(client.getId()));
     }
 
     @PostMapping
     public ResponseEntity<EndCustomer> create(@RequestBody EndCustomer data, Authentication auth) {
-        Client client = getAuthClient(auth);
+        Employee client = getAuthClient(auth);
         EndCustomer created = service.create(client, data);
         return ResponseEntity.status(HttpStatus.CREATED).body(created);
     }
 
     @GetMapping("/{id}")
     public ResponseEntity<EndCustomer> get(@PathVariable Long id, Authentication auth) {
-        Client client = getAuthClient(auth);
+        Employee client = getAuthClient(auth);
         return service.findByIdAndClient(id, client)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
@@ -52,7 +52,7 @@ public class ClientEndCustomerController {
     public ResponseEntity<EndCustomer> update(@PathVariable Long id,
                                               @RequestBody EndCustomer data,
                                               Authentication auth) {
-        Client client = getAuthClient(auth);
+        Employee client = getAuthClient(auth);
         return service.update(id, data, client)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
@@ -60,7 +60,7 @@ public class ClientEndCustomerController {
 
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> delete(@PathVariable Long id, Authentication auth) {
-        Client client = getAuthClient(auth);
+        Employee client = getAuthClient(auth);
         if (service.delete(id, client)) return ResponseEntity.noContent().build();
         return ResponseEntity.notFound().build();
     }

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/controller/ClientProviderController.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/controller/ClientProviderController.java
@@ -3,8 +3,8 @@ package grupo5.gestion_inventario.controller;
 
 import grupo5.gestion_inventario.clientpanel.dto.ProviderRequest;
 import grupo5.gestion_inventario.clientpanel.model.Provider;
-import grupo5.gestion_inventario.model.Client;
-import grupo5.gestion_inventario.repository.ClientRepository;
+import grupo5.gestion_inventario.model.Employee;
+import grupo5.gestion_inventario.repository.EmployeeRepository;
 import grupo5.gestion_inventario.service.ProviderService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,35 +19,35 @@ import java.util.List;
 public class ClientProviderController {
 
     private final ProviderService providerService;
-    private final ClientRepository clientRepository;
+    private final EmployeeRepository employeeRepository;
 
-    public ClientProviderController(ProviderService providerService, ClientRepository clientRepository) {
+    public ClientProviderController(ProviderService providerService, EmployeeRepository employeeRepository) {
         this.providerService = providerService;
-        this.clientRepository = clientRepository;
+        this.employeeRepository = employeeRepository;
     }
 
-    private Client getAuthenticatedClient(Authentication auth) {
-        return clientRepository.findByEmail(auth.getName())
+    private Employee getAuthenticatedClient(Authentication auth) {
+        return employeeRepository.findByEmail(auth.getName())
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Cliente no autenticado"));
     }
 
     @GetMapping
     public ResponseEntity<List<Provider>> listProviders(Authentication auth) {
-        Client client = getAuthenticatedClient(auth);
+        Employee client = getAuthenticatedClient(auth);
         List<Provider> providers = providerService.findByClientId(client.getId());
         return ResponseEntity.ok(providers);
     }
 
     @PostMapping
     public ResponseEntity<Provider> createProvider(@RequestBody ProviderRequest request, Authentication auth) {
-        Client client = getAuthenticatedClient(auth);
+        Employee client = getAuthenticatedClient(auth);
         Provider createdProvider = providerService.create(client, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdProvider);
     }
 
     @GetMapping("/{providerId}")
     public ResponseEntity<Provider> getProviderById(@PathVariable Long providerId, Authentication auth) {
-        Client client = getAuthenticatedClient(auth);
+        Employee client = getAuthenticatedClient(auth);
         return providerService.findByIdAndClient(providerId, client)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
@@ -55,7 +55,7 @@ public class ClientProviderController {
 
     @PutMapping("/{providerId}")
     public ResponseEntity<Provider> updateProvider(@PathVariable Long providerId, @RequestBody ProviderRequest request, Authentication auth) {
-        Client client = getAuthenticatedClient(auth);
+        Employee client = getAuthenticatedClient(auth);
         return providerService.update(providerId, request, client)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
@@ -63,7 +63,7 @@ public class ClientProviderController {
 
     @DeleteMapping("/{providerId}")
     public ResponseEntity<Void> deleteProvider(@PathVariable Long providerId, Authentication auth) {
-        Client client = getAuthenticatedClient(auth);
+        Employee client = getAuthenticatedClient(auth);
         if (providerService.delete(providerId, client)) {
             return ResponseEntity.noContent().build();
         }
@@ -77,8 +77,8 @@ public class ClientProviderController {
 
 import grupo5.gestion_inventario.clientpanel.dto.ProviderRequest;
 import grupo5.gestion_inventario.clientpanel.model.Provider;
-import grupo5.gestion_inventario.model.Client;
-import grupo5.gestion_inventario.repository.ClientRepository;
+import grupo5.gestion_inventario.model.Employee;
+import grupo5.gestion_inventario.repository.EmployeeRepository;
 import grupo5.gestion_inventario.service.ProviderService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -90,15 +90,15 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/client/providers")
-@PreAuthorize("hasRole('CLIENT')")
+@PreAuthorize("hasAuthority('ADMIN')")
 public class ClientProviderController {
 
     private final ProviderService providerService;
-    private final ClientRepository clientRepository;
+    private final EmployeeRepository employeeRepository;
 
-    public ClientProviderController(ProviderService providerService, ClientRepository clientRepository) {
+    public ClientProviderController(ProviderService providerService, EmployeeRepository employeeRepository) {
         this.providerService = providerService;
-        this.clientRepository = clientRepository;
+        this.employeeRepository = employeeRepository;
     }
 
     /**
@@ -107,7 +107,7 @@ public class ClientProviderController {
 
     @PostMapping
     public ResponseEntity<Provider> createProvider(@RequestBody ProviderRequest request, Authentication auth) {
-        Client client = clientRepository.findByEmail(auth.getName())
+        Employee client = employeeRepository.findByEmail(auth.getName())
                 .orElseThrow(() -> new IllegalArgumentException("Cliente no encontrado"));
         Provider createdProvider = providerService.create(client, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdProvider);
@@ -119,7 +119,7 @@ public class ClientProviderController {
 
     @GetMapping
     public ResponseEntity<List<Provider>> getProviders(Authentication auth) {
-        Client client = clientRepository.findByEmail(auth.getName())
+        Employee client = employeeRepository.findByEmail(auth.getName())
                 .orElseThrow(() -> new IllegalArgumentException("Cliente no encontrado"));
         List<Provider> providers = providerService.findByClientId(client.getId());
         return ResponseEntity.ok(providers);
@@ -131,7 +131,7 @@ public class ClientProviderController {
 
     @GetMapping("/{id}")
     public ResponseEntity<Provider> getProviderById(@PathVariable Long id, Authentication auth) {
-        Client client = clientRepository.findByEmail(auth.getName())
+        Employee client = employeeRepository.findByEmail(auth.getName())
                 .orElseThrow(() -> new IllegalArgumentException("Cliente no encontrado"));
         return providerService.findByIdAndClient(id, client)
                 .map(ResponseEntity::ok)
@@ -143,7 +143,7 @@ public class ClientProviderController {
      * Actualiza un proveedor existente.
     @PutMapping("/{id}")
     public ResponseEntity<Provider> updateProvider(@PathVariable Long id, @RequestBody ProviderRequest request, Authentication auth) {
-        Client client = clientRepository.findByEmail(auth.getName())
+        Employee client = employeeRepository.findByEmail(auth.getName())
                 .orElseThrow(() -> new IllegalArgumentException("Cliente no encontrado"));
         return providerService.update(id, request, client)
                 .map(ResponseEntity::ok)
@@ -156,7 +156,7 @@ public class ClientProviderController {
 
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteProvider(@PathVariable Long id, Authentication auth) {
-        Client client = clientRepository.findByEmail(auth.getName())
+        Employee client = employeeRepository.findByEmail(auth.getName())
                 .orElseThrow(() -> new IllegalArgumentException("Cliente no encontrado"));
         boolean deleted = providerService.delete(id, client);
         if (deleted) {

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/controller/ClientSalesController.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/controller/ClientSalesController.java
@@ -3,7 +3,7 @@ package grupo5.gestion_inventario.controller;
 import grupo5.gestion_inventario.clientpanel.dto.SaleDto;
 import grupo5.gestion_inventario.clientpanel.dto.SaleRequest;
 import grupo5.gestion_inventario.service.SalesService;
-import grupo5.gestion_inventario.repository.ClientRepository;
+import grupo5.gestion_inventario.repository.EmployeeRepository;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
@@ -13,19 +13,19 @@ import org.springframework.web.bind.annotation.*;
 public class ClientSalesController {
 
     private final SalesService     salesService;
-    private final ClientRepository clientRepo;
+    private final EmployeeRepository employeeRepo;
 
     public ClientSalesController(SalesService salesService,
-                                 ClientRepository clientRepo) {
+                                 EmployeeRepository employeeRepo) {
         this.salesService = salesService;
-        this.clientRepo   = clientRepo;
+        this.employeeRepo   = employeeRepo;
     }
 
     @PostMapping
     public ResponseEntity<SaleDto> createSale(@RequestBody SaleRequest request,
                                               Authentication auth) {
         // Busca el ID del cliente (Long) usando el usuario autenticado
-        Long clientId = clientRepo.findByEmail(auth.getName())
+        Long clientId = employeeRepo.findByEmail(auth.getName())
                 .orElseThrow(() -> new IllegalArgumentException("Cliente no encontrado"))
                 .getId();
 

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/controller/EmployeeController.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/controller/EmployeeController.java
@@ -1,0 +1,42 @@
+package grupo5.gestion_inventario.controller;
+
+import grupo5.gestion_inventario.clientpanel.dto.EmployeeRequest;
+import grupo5.gestion_inventario.model.Employee;
+import grupo5.gestion_inventario.model.Role;
+import grupo5.gestion_inventario.service.EmployeeService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/client/employees")
+@PreAuthorize("hasAuthority('ADMIN')")
+public class EmployeeController {
+
+    private final EmployeeService service;
+    private final PasswordEncoder passwordEncoder;
+
+    public EmployeeController(EmployeeService service, PasswordEncoder passwordEncoder) {
+        this.service = service;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<Employee>> list() {
+        return ResponseEntity.ok(service.findAll());
+    }
+
+    @PostMapping
+    public ResponseEntity<Employee> create(@RequestBody EmployeeRequest req) {
+        Employee e = new Employee();
+        e.setName(req.getName());
+        e.setEmail(req.getEmail());
+        e.setPasswordHash(passwordEncoder.encode(req.getPassword()));
+        e.setRole(req.getRole() != null ? req.getRole() : Role.CASHIER);
+        return new ResponseEntity<>(service.create(e), HttpStatus.CREATED);
+    }
+}

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/controller/ProductController.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/controller/ProductController.java
@@ -2,10 +2,11 @@ package grupo5.gestion_inventario.controller;
 
 import grupo5.gestion_inventario.clientpanel.dto.ProductDto;
 import grupo5.gestion_inventario.clientpanel.dto.ProductRequest;
-import grupo5.gestion_inventario.model.Client;
-import grupo5.gestion_inventario.repository.ClientRepository;
+import grupo5.gestion_inventario.model.Employee;
+import grupo5.gestion_inventario.repository.EmployeeRepository;
 import grupo5.gestion_inventario.service.ProductService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
@@ -13,21 +14,22 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/client/products")
+@PreAuthorize("hasAuthority('ADMIN')")
 public class ProductController {
 
     private final ProductService   productService;
-    private final ClientRepository clientRepo;
+    private final EmployeeRepository employeeRepo;
 
     public ProductController(ProductService productService,
-                             ClientRepository clientRepo) {
+                             EmployeeRepository employeeRepo) {
         this.productService = productService;
-        this.clientRepo     = clientRepo;
+        this.employeeRepo     = employeeRepo;
     }
 
     @PostMapping
     public ResponseEntity<ProductDto> create(@RequestBody ProductRequest req,
                                              Authentication auth) {
-        Client client = clientRepo.findByEmail(auth.getName())
+        Employee client = employeeRepo.findByEmail(auth.getName())
                 .orElseThrow(() -> new IllegalArgumentException("Cliente no encontrado"));
 
         ProductDto dto = productService.create(client, req);
@@ -37,7 +39,7 @@ public class ProductController {
     @GetMapping
     public ResponseEntity<List<ProductDto>> list(Authentication auth) {
         String email = auth.getName();
-        Client client = clientRepo.findByEmail(email)
+        Employee client = employeeRepo.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("Cliente no encontrado: " + email));
 
         List<ProductDto> dtos = productService.findByClientId(client.getId());
@@ -46,7 +48,7 @@ public class ProductController {
 
     @GetMapping("/{id}")
     public ResponseEntity<ProductDto> getProductById(@PathVariable Long id, Authentication auth) {
-        Client client = clientRepo.findByEmail(auth.getName())
+        Employee client = employeeRepo.findByEmail(auth.getName())
                 .orElseThrow(() -> new IllegalArgumentException("Cliente no encontrado"));
 
         return productService.findDtoByIdAndClient(id, client)
@@ -58,7 +60,7 @@ public class ProductController {
     public ResponseEntity<ProductDto> updateProduct(@PathVariable Long id,
                                                     @RequestBody ProductRequest req,
                                                     Authentication auth) {
-        Client client = clientRepo.findByEmail(auth.getName())
+        Employee client = employeeRepo.findByEmail(auth.getName())
                 .orElseThrow(() -> new IllegalArgumentException("Cliente no encontrado"));
 
         return productService.updateProduct(id, req, client)
@@ -73,7 +75,7 @@ public class ProductController {
      */
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteProduct(@PathVariable Long id, Authentication auth) {
-        Client client = clientRepo.findByEmail(auth.getName())
+        Employee client = employeeRepo.findByEmail(auth.getName())
                 .orElseThrow(() -> new IllegalArgumentException("Cliente no encontrado"));
 
         boolean deleted = productService.deleteProduct(id, client);

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/model/Employee.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/model/Employee.java
@@ -4,12 +4,14 @@ import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import org.hibernate.annotations.CreationTimestamp;
 
+import grupo5.gestion_inventario.model.Role;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Entity
 @Table(name = "client")
-public class Client {
+public class Employee {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,6 +26,10 @@ public class Client {
 
     @Column(nullable = false)
     private String passwordHash;                // SIEMPRE BCrypt
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
 
     /* -------- info extra -------- */
     private String telefono;
@@ -49,6 +55,9 @@ public class Client {
 
     public String getPasswordHash()  { return passwordHash; }
     public void   setPasswordHash(String p) { this.passwordHash = p; }
+
+    public Role getRole() { return role; }
+    public void setRole(Role role) { this.role = role; }
 
     public String getTelefono()      { return telefono; }
     public void   setTelefono(String t){ this.telefono = t; }

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/model/Product.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/model/Product.java
@@ -42,7 +42,7 @@ public class Product {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "client_id", nullable = false)
     @JsonBackReference
-    private Client client;
+    private Employee client;
 
     // — Constructores —
 
@@ -55,7 +55,7 @@ public class Product {
                    BigDecimal price,
                    Integer stockQuantity,
                    Integer lowStockThreshold,
-                   Client client) {
+                   Employee client) {
         this.code              = code;
         this.name              = name;
         this.description       = description;
@@ -121,10 +121,10 @@ public class Product {
         this.lowStockThreshold = lowStockThreshold;
     }
 
-    public Client getClient() {
+    public Employee getClient() {
         return client;
     }
-    public void setClient(Client client) {
+    public void setClient(Employee client) {
         this.client = client;
     }
 }

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/model/Role.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/model/Role.java
@@ -1,0 +1,6 @@
+package grupo5.gestion_inventario.model;
+
+public enum Role {
+    ADMIN,
+    CASHIER
+}

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/repository/EmployeeRepository.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/repository/EmployeeRepository.java
@@ -1,17 +1,17 @@
 package grupo5.gestion_inventario.repository;
 
-import grupo5.gestion_inventario.model.Client;
+import grupo5.gestion_inventario.model.Employee;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface ClientRepository extends JpaRepository<Client, Long> {
+public interface EmployeeRepository extends JpaRepository<Employee, Long> {
 
     /* login por e-mail (username) */
-    Optional<Client> findByEmail(String email);
+    Optional<Employee> findByEmail(String email);
 
     /* si algún día permites “name” como usuario: */
-    Optional<Client> findByName(String name);
+    Optional<Employee> findByName(String name);
 
     long countByPlan(String plan);
 

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/security/CustomUserDetailsService.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/security/CustomUserDetailsService.java
@@ -1,7 +1,8 @@
 package grupo5.gestion_inventario.security;
 
-import grupo5.gestion_inventario.model.Client;
-import grupo5.gestion_inventario.repository.ClientRepository;
+import grupo5.gestion_inventario.model.Employee;
+import grupo5.gestion_inventario.model.Role;
+import grupo5.gestion_inventario.repository.EmployeeRepository;
 import grupo5.gestion_inventario.superpanel.model.AdminUser;
 import grupo5.gestion_inventario.superpanel.repository.AdminUserRepository;
 import org.springframework.security.core.userdetails.User;
@@ -14,12 +15,12 @@ import org.springframework.stereotype.Service;
 public class CustomUserDetailsService implements UserDetailsService {
 
     private final AdminUserRepository adminRepo;
-    private final ClientRepository    clientRepo;
+    private final EmployeeRepository    employeeRepo;
 
     public CustomUserDetailsService(AdminUserRepository adminRepo,
-                                    ClientRepository clientRepo) {
+                                    EmployeeRepository employeeRepo) {
         this.adminRepo  = adminRepo;
-        this.clientRepo = clientRepo;
+        this.employeeRepo = employeeRepo;
     }
 
     @Override
@@ -37,17 +38,18 @@ public class CustomUserDetailsService implements UserDetailsService {
                     .build();
         }
 
-        /* -------- ¿Client? --------
+        /* -------- ¿Employee? --------
            Busca por email; si quisieras aceptar “name”, agrega otro findBy… */
-        Client client = clientRepo.findByEmail(username)
-                .orElseGet(() -> clientRepo.findByName(username)
+        Employee employee = employeeRepo.findByEmail(username)
+                .orElseGet(() -> employeeRepo.findByName(username)
                         .orElse(null));
 
-        if (client != null) {
+        if (employee != null) {
+            String role = employee.getRole() != null ? employee.getRole().name() : "CASHIER";
             return User.builder()
-                    .username(client.getEmail())      // clave del JWT
-                    .password(client.getPasswordHash())
-                    .roles("CLIENT")
+                    .username(employee.getEmail())      // clave del JWT
+                    .password(employee.getPasswordHash())
+                    .roles(role)
                     .build();
         }
 

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/service/CashRegisterSessionService.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/service/CashRegisterSessionService.java
@@ -11,19 +11,19 @@ import org.springframework.transaction.annotation.Transactional;
 
 import grupo5.gestion_inventario.clientpanel.model.CashRegisterSession;
 import grupo5.gestion_inventario.clientpanel.repository.CashRegisterSessionRepository;
-import grupo5.gestion_inventario.model.Client;
-import grupo5.gestion_inventario.repository.ClientRepository;
+import grupo5.gestion_inventario.model.Employee;
+import grupo5.gestion_inventario.repository.EmployeeRepository;
 
 @Service
 public class CashRegisterSessionService {
 
     private final CashRegisterSessionRepository sessionRepo;
-    private final ClientRepository clientRepo;
+    private final EmployeeRepository employeeRepo;
 
     public CashRegisterSessionService(CashRegisterSessionRepository sessionRepo,
-                                      ClientRepository clientRepo) {
+                                      EmployeeRepository employeeRepo) {
         this.sessionRepo = sessionRepo;
-        this.clientRepo  = clientRepo;
+        this.employeeRepo  = employeeRepo;
     }
 
     /**
@@ -31,7 +31,7 @@ public class CashRegisterSessionService {
      */
     @Transactional
     public CashRegisterSession openSession(Long clientId, BigDecimal openingBalance) {
-        Client client = clientRepo.findById(clientId)
+        Employee client = employeeRepo.findById(clientId)
                 .orElseThrow(() -> new IllegalArgumentException("Cliente no encontrado: " + clientId));
 
         Optional<CashRegisterSession> open = sessionRepo.findByClientIdAndClosedAtIsNull(clientId);
@@ -68,7 +68,7 @@ public class CashRegisterSessionService {
      */
     @Transactional(readOnly = true)
     public List<CashRegisterSession> listSessions(Long clientId) {
-        if (!clientRepo.existsById(clientId)) {
+        if (!employeeRepo.existsById(clientId)) {
             throw new IllegalArgumentException("Cliente no encontrado: " + clientId);
         }
         return sessionRepo.findByClientId(clientId);

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/service/EmployeeService.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/service/EmployeeService.java
@@ -5,9 +5,9 @@
 package grupo5.gestion_inventario.service;
 
 import java.util.List;
-import grupo5.gestion_inventario.model.Client;
+import grupo5.gestion_inventario.model.Employee;
 import org.springframework.stereotype.Service;
-import grupo5.gestion_inventario.repository.ClientRepository;
+import grupo5.gestion_inventario.repository.EmployeeRepository;
 
 /**
  *
@@ -16,29 +16,29 @@ import grupo5.gestion_inventario.repository.ClientRepository;
 
 
 @Service
-public class ClientService {
+public class EmployeeService {
 
-    private final ClientRepository repo;
+    private final EmployeeRepository repo;
 
-    public ClientService(ClientRepository repo) {
+    public EmployeeService(EmployeeRepository repo) {
         this.repo = repo;
     }
 
-    public Client create(Client c) {
+    public Employee create(Employee c) {
         return repo.save(c);
     }
 
-    public List<Client> findAll() {
+    public List<Employee> findAll() {
         return repo.findAll();
     }
 
-    public Client findById(Long id) {
+    public Employee findById(Long id) {
         return repo.findById(id)
-                .orElseThrow(() -> new RuntimeException("Cliente no encontrado"));
+                .orElseThrow(() -> new RuntimeException("Employeee no encontrado"));
     }
 
-    public Client update(Long id, Client data) {
-        Client c = findById(id);
+    public Employee update(Long id, Employee data) {
+        Employee c = findById(id);
         c.setName(data.getName());
         c.setEmail(data.getEmail());
         return repo.save(c);
@@ -60,14 +60,14 @@ public class ClientService {
 
     /** Marca un cliente como INACTIVO */
     public void inactivate(Long id) {
-        Client c = findById(id);
+        Employee c = findById(id);
         c.setEstado("INACTIVO");
         repo.save(c);
     }
 
     /** Marca un cliente como ACTIVO */
     public void activate(Long id) {
-        Client c = findById(id);
+        Employee c = findById(id);
         c.setEstado("ACTIVO");
         repo.save(c);
     }

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/service/EndCustomerService.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/service/EndCustomerService.java
@@ -2,8 +2,8 @@ package grupo5.gestion_inventario.service;
 
 import grupo5.gestion_inventario.clientpanel.model.EndCustomer;
 import grupo5.gestion_inventario.clientpanel.repository.EndCustomerRepository;
-import grupo5.gestion_inventario.model.Client;
-import grupo5.gestion_inventario.repository.ClientRepository;
+import grupo5.gestion_inventario.model.Employee;
+import grupo5.gestion_inventario.repository.EmployeeRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,21 +13,21 @@ import java.util.Optional;
 @Service
 public class EndCustomerService {
     private final EndCustomerRepository repo;
-    private final ClientRepository clientRepo;
+    private final EmployeeRepository employeeRepo;
 
-    public EndCustomerService(EndCustomerRepository repo, ClientRepository clientRepo) {
+    public EndCustomerService(EndCustomerRepository repo, EmployeeRepository employeeRepo) {
         this.repo = repo;
-        this.clientRepo = clientRepo;
+        this.employeeRepo = employeeRepo;
     }
 
     @Transactional
-    public EndCustomer create(Client client, EndCustomer customer) {
+    public EndCustomer create(Employee client, EndCustomer customer) {
         customer.setClient(client);
         return repo.save(customer);
     }
 
     @Transactional
-    public Optional<EndCustomer> update(Long id, EndCustomer data, Client client) {
+    public Optional<EndCustomer> update(Long id, EndCustomer data, Employee client) {
         return repo.findById(id)
                 .filter(c -> c.getClient().getId().equals(client.getId()))
                 .map(c -> {
@@ -38,7 +38,7 @@ public class EndCustomerService {
     }
 
     @Transactional
-    public boolean delete(Long id, Client client) {
+    public boolean delete(Long id, Employee client) {
         return repo.findById(id)
                 .filter(c -> c.getClient().getId().equals(client.getId()))
                 .map(c -> { repo.delete(c); return true; })
@@ -47,14 +47,14 @@ public class EndCustomerService {
 
     @Transactional(readOnly = true)
     public List<EndCustomer> listByClient(Long clientId) {
-        if (!clientRepo.existsById(clientId)) {
+        if (!employeeRepo.existsById(clientId)) {
             throw new IllegalArgumentException("Cliente no encontrado: " + clientId);
         }
         return repo.findByClientId(clientId);
     }
 
     @Transactional(readOnly = true)
-    public Optional<EndCustomer> findByIdAndClient(Long id, Client client) {
+    public Optional<EndCustomer> findByIdAndClient(Long id, Employee client) {
         return repo.findById(id).filter(c -> c.getClient().getId().equals(client.getId()));
     }
 }

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/service/ExpenseService.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/service/ExpenseService.java
@@ -6,8 +6,8 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import grupo5.gestion_inventario.model.Client;
-import grupo5.gestion_inventario.repository.ClientRepository;
+import grupo5.gestion_inventario.model.Employee;
+import grupo5.gestion_inventario.repository.EmployeeRepository;
 import grupo5.gestion_inventario.clientpanel.model.Expense;
 import grupo5.gestion_inventario.clientpanel.repository.ExpenseRepository;
 
@@ -15,12 +15,12 @@ import grupo5.gestion_inventario.clientpanel.repository.ExpenseRepository;
 public class ExpenseService {
 
     private final ExpenseRepository expenseRepo;
-    private final ClientRepository  clientRepo;
+    private final EmployeeRepository  employeeRepo;
 
     public ExpenseService(ExpenseRepository expenseRepo,
-                          ClientRepository clientRepo) {
+                          EmployeeRepository employeeRepo) {
         this.expenseRepo = expenseRepo;
-        this.clientRepo  = clientRepo;
+        this.employeeRepo  = employeeRepo;
     }
 
     /**
@@ -28,7 +28,7 @@ public class ExpenseService {
      */
     @Transactional
     public Expense create(Long clientId, Expense expense) {
-        Client client = clientRepo.findById(clientId)
+        Employee client = employeeRepo.findById(clientId)
                 .orElseThrow(() -> new IllegalArgumentException("Cliente no encontrado: " + clientId));
         expense.setClient(client);
         return expenseRepo.save(expense);
@@ -39,7 +39,7 @@ public class ExpenseService {
      */
     @Transactional(readOnly = true)
     public List<Expense> findByClientId(Long clientId) {
-        if (!clientRepo.existsById(clientId)) {
+        if (!employeeRepo.existsById(clientId)) {
             throw new IllegalArgumentException("Cliente no encontrado: " + clientId);
         }
         return expenseRepo.findByClientId(clientId);

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/service/ProductService.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/service/ProductService.java
@@ -3,9 +3,9 @@ package grupo5.gestion_inventario.service;
 import grupo5.gestion_inventario.clientpanel.dto.ProductDto;
 import grupo5.gestion_inventario.clientpanel.dto.ProductRequest;
 import grupo5.gestion_inventario.model.Product;
-import grupo5.gestion_inventario.model.Client;
+import grupo5.gestion_inventario.model.Employee;
 import grupo5.gestion_inventario.repository.ProductRepository;
-import grupo5.gestion_inventario.repository.ClientRepository;
+import grupo5.gestion_inventario.repository.EmployeeRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,16 +17,16 @@ import java.util.stream.Collectors;
 public class ProductService {
 
     private final ProductRepository productRepo;
-    private final ClientRepository  clientRepo;
+    private final EmployeeRepository  employeeRepo;
 
     public ProductService(ProductRepository productRepo,
-                          ClientRepository clientRepo) {
+                          EmployeeRepository employeeRepo) {
         this.productRepo = productRepo;
-        this.clientRepo  = clientRepo;
+        this.employeeRepo  = employeeRepo;
     }
 
     @Transactional
-    public ProductDto create(Client client, ProductRequest req) {
+    public ProductDto create(Employee client, ProductRequest req) {
         Product product = new Product();
         product.setClient(client);
         product.setCode(req.getCode());
@@ -45,7 +45,7 @@ public class ProductService {
 
     // --- NUEVO MÉTODO PARA ACTUALIZAR UN PRODUCTO ---
     @Transactional
-    public Optional<ProductDto> updateProduct(Long productId, ProductRequest req, Client client) {
+    public Optional<ProductDto> updateProduct(Long productId, ProductRequest req, Employee client) {
         return productRepo.findById(productId)
                 // Nos aseguramos de que el producto pertenezca al cliente autenticado
                 .filter(product -> product.getClient().getId().equals(client.getId()))
@@ -67,7 +67,7 @@ public class ProductService {
 
     @Transactional(readOnly = true)
     public List<ProductDto> findByClientId(Long clientId) {
-        if (!clientRepo.existsById(clientId)) {
+        if (!employeeRepo.existsById(clientId)) {
             throw new IllegalArgumentException("Cliente no encontrado: " + clientId);
         }
         return productRepo.findByClientId(clientId).stream()
@@ -77,14 +77,14 @@ public class ProductService {
 
     // --- NUEVO MÉTODO PARA BUSCAR UN ÚNICO DTO ---
     @Transactional(readOnly = true)
-    public Optional<ProductDto> findDtoByIdAndClient(Long productId, Client client) {
+    public Optional<ProductDto> findDtoByIdAndClient(Long productId, Employee client) {
         return productRepo.findById(productId)
                 .filter(product -> product.getClient().getId().equals(client.getId()))
                 .map(this::toDto); // Usamos el helper
     }
     // --- NUEVO MÉTODO PARA ELIMINAR UN PRODUCTO ---
     @Transactional
-    public boolean deleteProduct(Long productId, Client client) {
+    public boolean deleteProduct(Long productId, Employee client) {
         return productRepo.findById(productId)
                 .filter(product -> product.getClient().getId().equals(client.getId())) // Verificación de propiedad
                 .map(product -> {
@@ -96,7 +96,7 @@ public class ProductService {
 
     @Transactional(readOnly = true)
     public long countLowStock(Long clientId) {
-        if (!clientRepo.existsById(clientId)) {
+        if (!employeeRepo.existsById(clientId)) {
             throw new IllegalArgumentException("Cliente no encontrado: " + clientId);
         }
         return productRepo.countLowStock(clientId);

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/service/ProviderService.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/service/ProviderService.java
@@ -2,8 +2,8 @@
 package grupo5.gestion_inventario.service;
 
 import grupo5.gestion_inventario.clientpanel.dto.ProviderRequest;
-import grupo5.gestion_inventario.model.Client;
-import grupo5.gestion_inventario.repository.ClientRepository;
+import grupo5.gestion_inventario.model.Employee;
+import grupo5.gestion_inventario.repository.EmployeeRepository;
 import grupo5.gestion_inventario.clientpanel.model.Provider;
 import grupo5.gestion_inventario.clientpanel.repository.ProviderRepository;
 import org.springframework.stereotype.Service;
@@ -16,19 +16,19 @@ import java.util.Optional;
 public class ProviderService {
 
     private final ProviderRepository providerRepo;
-    private final ClientRepository   clientRepo;
+    private final EmployeeRepository   employeeRepo;
 
     public ProviderService(ProviderRepository providerRepo,
-                           ClientRepository clientRepo) {
+                           EmployeeRepository employeeRepo) {
         this.providerRepo = providerRepo;
-        this.clientRepo   = clientRepo;
+        this.employeeRepo   = employeeRepo;
     }
 
     /**
      * Crea un proveedor para un cliente dado usando los datos de un DTO.
      */
     @Transactional
-    public Provider create(Client client, ProviderRequest request) {
+    public Provider create(Employee client, ProviderRequest request) {
         Provider provider = new Provider();
         provider.setClient(client);
         provider.setName(request.getName());
@@ -41,7 +41,7 @@ public class ProviderService {
      * Actualiza un proveedor existente, verificando que pertenece al cliente.
      */
     @Transactional
-    public Optional<Provider> update(Long providerId, ProviderRequest request, Client client) {
+    public Optional<Provider> update(Long providerId, ProviderRequest request, Employee client) {
         return providerRepo.findById(providerId)
                 // 1. Nos aseguramos que el proveedor pertenezca al cliente correcto.
                 .filter(provider -> provider.getClient().getId().equals(client.getId()))
@@ -60,7 +60,7 @@ public class ProviderService {
     @Transactional(readOnly = true)
     public List<Provider> findByClientId(Long clientId) {
         // Este método se mantiene, es útil para listados.
-        if (!clientRepo.existsById(clientId)) {
+        if (!employeeRepo.existsById(clientId)) {
             throw new IllegalArgumentException("Cliente no encontrado: " + clientId);
         }
         return providerRepo.findByClientId(clientId);
@@ -70,7 +70,7 @@ public class ProviderService {
      * Busca un proveedor específico por su ID, verificando que pertenece al cliente.
      */
     @Transactional(readOnly = true)
-    public Optional<Provider> findByIdAndClient(Long providerId, Client client) {
+    public Optional<Provider> findByIdAndClient(Long providerId, Employee client) {
         return providerRepo.findById(providerId)
                 .filter(p -> p.getClient().getId().equals(client.getId()));
     }
@@ -81,7 +81,7 @@ public class ProviderService {
      * @return true si existía y se borró.
      */
     @Transactional
-    public boolean delete(Long providerId, Client client) {
+    public boolean delete(Long providerId, Employee client) {
         return providerRepo.findById(providerId)
                 .filter(p -> p.getClient().getId().equals(client.getId()))
                 .map(p -> {

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/service/PurchaseOrderService.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/service/PurchaseOrderService.java
@@ -9,9 +9,9 @@ import grupo5.gestion_inventario.clientpanel.model.StockMovement;
 import grupo5.gestion_inventario.clientpanel.repository.ProviderRepository;
 import grupo5.gestion_inventario.clientpanel.repository.PurchaseOrderRepository;
 import grupo5.gestion_inventario.clientpanel.repository.StockMovementRepository;
-import grupo5.gestion_inventario.model.Client;
+import grupo5.gestion_inventario.model.Employee;
 import grupo5.gestion_inventario.model.Product;
-import grupo5.gestion_inventario.repository.ClientRepository;
+import grupo5.gestion_inventario.repository.EmployeeRepository;
 import grupo5.gestion_inventario.repository.ProductRepository;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,7 +37,7 @@ public class PurchaseOrderService {
     private ProductRepository productRepository;
 
     @Autowired
-    private ClientRepository clientRepository;
+    private EmployeeRepository employeeRepository;
 
     @Autowired
     private StockMovementRepository stockMovementRepository;
@@ -57,7 +57,7 @@ public class PurchaseOrderService {
         // 1. Validar la existencia de las entidades principales
         Provider provider = providerRepository.findById(request.getProviderId())
                 .orElseThrow(() -> new EntityNotFoundException("Proveedor no encontrado con id: " + request.getProviderId()));
-        Client client = clientRepository.findById(request.getClientId())
+        Employee client = employeeRepository.findById(request.getClientId())
                 .orElseThrow(() -> new EntityNotFoundException("Cliente no encontrado con id: " + request.getClientId()));
 
         // 2. Crear la entidad PurchaseOrder

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/service/SalesService.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/service/SalesService.java
@@ -9,9 +9,9 @@ import grupo5.gestion_inventario.clientpanel.model.SaleItem;
 import grupo5.gestion_inventario.clientpanel.model.EndCustomer;
 import grupo5.gestion_inventario.clientpanel.repository.SaleRepository;
 import grupo5.gestion_inventario.clientpanel.repository.EndCustomerRepository;
-import grupo5.gestion_inventario.model.Client;
+import grupo5.gestion_inventario.model.Employee;
 import grupo5.gestion_inventario.model.Product;
-import grupo5.gestion_inventario.repository.ClientRepository;
+import grupo5.gestion_inventario.repository.EmployeeRepository;
 import grupo5.gestion_inventario.repository.ProductRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,16 +28,16 @@ import java.util.stream.Collectors;
 public class SalesService {
 
     private final SaleRepository saleRepo;
-    private final ClientRepository  clientRepo;
+    private final EmployeeRepository  employeeRepo;
     private final ProductRepository productRepo;
     private final EndCustomerRepository endCustomerRepo;
 
     public SalesService(SaleRepository saleRepo,
-                        ClientRepository clientRepo,
+                        EmployeeRepository employeeRepo,
                         ProductRepository productRepo,
                         EndCustomerRepository endCustomerRepo) {
         this.saleRepo    = saleRepo;
-        this.clientRepo  = clientRepo;
+        this.employeeRepo  = employeeRepo;
         this.productRepo = productRepo;
         this.endCustomerRepo = endCustomerRepo;
     }
@@ -49,7 +49,7 @@ public class SalesService {
 
         System.out.println("--- FECHA RECIBIDA EN EL SERVICIO: " + req.getSaleDate() + " ---");
 
-        Client client = clientRepo.findById(clientId)
+        Employee client = employeeRepo.findById(clientId)
                 .orElseThrow(() ->
                         new IllegalArgumentException("Cliente no encontrado: " + clientId));
 
@@ -101,7 +101,7 @@ public class SalesService {
 
     @Transactional(readOnly = true)
     public long countSalesToday(Long clientId) {
-        if (!clientRepo.existsById(clientId)) {
+        if (!employeeRepo.existsById(clientId)) {
             throw new IllegalArgumentException("Cliente no encontrado: " + clientId);
         }
         LocalDate today = LocalDate.now();
@@ -114,7 +114,7 @@ public class SalesService {
 
     @Transactional(readOnly = true)
     public List<SaleDto> findByClientId(Long clientId) {
-        if (!clientRepo.existsById(clientId)) {
+        if (!employeeRepo.existsById(clientId)) {
             throw new IllegalArgumentException("Cliente no encontrado: " + clientId);
         }
         return saleRepo.findByClientId(clientId).stream()
@@ -140,7 +140,7 @@ public class SalesService {
 
     @Transactional(readOnly = true)
     public List<SalesDailySummaryDto> summaryLastDays(Long clientId, int days) {
-        if (!clientRepo.existsById(clientId)) {
+        if (!employeeRepo.existsById(clientId)) {
             throw new IllegalArgumentException("Cliente no encontrado: " + clientId);
         }
 
@@ -168,7 +168,7 @@ public class SalesService {
     // --- ¡NUEVO MÉTODO AÑADIDO AQUÍ! ---
     @Transactional(readOnly = true)
     public List<ProfitabilitySummaryDto> getProfitabilitySummaryLastDays(Long clientId, int days) {
-        if (!clientRepo.existsById(clientId)) {
+        if (!employeeRepo.existsById(clientId)) {
             throw new IllegalArgumentException("Cliente no encontrado: " + clientId);
         }
 

--- a/gestion-inventario-frontend/src/components/client/EmployeesSection.jsx
+++ b/gestion-inventario-frontend/src/components/client/EmployeesSection.jsx
@@ -1,0 +1,31 @@
+import React, { useEffect, useState } from 'react';
+import { api } from '../../services/api';
+
+function EmployeesSection() {
+    const [employees, setEmployees] = useState([]);
+
+    useEffect(() => {
+        async function load() {
+            try {
+                const data = await api.get('/client/employees');
+                setEmployees(data);
+            } catch (err) {
+                console.error(err);
+            }
+        }
+        load();
+    }, []);
+
+    return (
+        <div>
+            <h2>Gestión de Empleados</h2>
+            <ul>
+                {employees.map(e => (
+                    <li key={e.id}>{e.name} - {e.role}</li>
+                ))}
+            </ul>
+        </div>
+    );
+}
+
+export default EmployeesSection;

--- a/gestion-inventario-frontend/src/pages/ClientPanelPage.jsx
+++ b/gestion-inventario-frontend/src/pages/ClientPanelPage.jsx
@@ -7,10 +7,12 @@ import SalesSection from '../components/client/SalesSection';
 import ProvidersSection from '../components/client/ProvidersSection';
 import PurchasesSection from '../components/client/PurchasesSection';
 import CustomersSection from '../components/client/CustomersSection';
+import EmployeesSection from '../components/client/EmployeesSection';
 
 function ClientPanelPage() {
     const navigate = useNavigate();
     const location = useLocation(); // Hook para leer la info de la URL actual
+    const role = localStorage.getItem('role');
 
     // La sección activa ahora se determina por el HASH de la URL, o es 'dashboard' por defecto
     const [activeSection, setActiveSection] = useState(location.hash.replace('#', '') || 'dashboard');
@@ -25,6 +27,7 @@ function ClientPanelPage() {
     const handleLogout = () => {
         localStorage.removeItem('jwt');
         localStorage.removeItem('clientId');
+        localStorage.removeItem('role');
         navigate('/login');
     };
 
@@ -45,6 +48,8 @@ function ClientPanelPage() {
                 return <CustomersSection />;
             case 'proveedores':
                 return <ProvidersSection />;
+            case 'empleados':
+                return <EmployeesSection />;
             case 'dashboard':
             default:
                 return <DashboardSection />;
@@ -58,11 +63,16 @@ function ClientPanelPage() {
                 <nav>
                     {/* Los botones ahora llaman a handleSectionChange para actualizar la URL */}
                     <button onClick={() => handleSectionChange('dashboard')}>Dashboard</button>
-                    <button onClick={() => handleSectionChange('inventario')}>Inventario</button>
+                    {role === 'ADMIN' && (
+                        <>
+                            <button onClick={() => handleSectionChange('inventario')}>Inventario</button>
+                            <button onClick={() => handleSectionChange('compras')}>Compras</button>
+                            <button onClick={() => handleSectionChange('proveedores')}>Proveedores</button>
+                            <button onClick={() => handleSectionChange('empleados')}>Empleados</button>
+                        </>
+                    )}
                     <button onClick={() => handleSectionChange('ventas')}>Ventas</button>
-                    <button onClick={() => handleSectionChange('compras')}>Compras</button>
                     <button onClick={() => handleSectionChange('clientes')}>Clientes</button>
-                    <button onClick={() => handleSectionChange('proveedores')}>Proveedores</button>
                     <button id="logout-btn" onClick={handleLogout}>Cerrar sesión</button>
                 </nav>
             </header>

--- a/gestion-inventario-frontend/src/pages/LoginPage.jsx
+++ b/gestion-inventario-frontend/src/pages/LoginPage.jsx
@@ -16,21 +16,23 @@ function LoginPage() {
         try {
             // Usamos nuestro cliente API para hacer la petición POST
             const response = await api.post('/auth/login', { username, password });
-            const { token } = response;
+            const { token, role } = response;
 
             if (!token) {
                 throw new Error('No se recibió un token del servidor.');
             }
 
-            // Guardamos el JWT en el almacenamiento local
+            // Guardamos el JWT y el rol en el almacenamiento local
             localStorage.setItem('jwt', token);
+            if (role) {
+                localStorage.setItem('role', role);
+            }
 
-            // Decodificamos el token para obtener los roles y el clientId
+            // Decodificamos el token para obtener el clientId
             const [, payloadB64] = token.split('.');
             const padded = payloadB64.replace(/-/g, '+').replace(/_/g, '/') + '=='.slice(0, (4 - payloadB64.length % 4) % 4);
             const decoded = JSON.parse(atob(padded));
 
-            const roles = decoded.roles || [];
             const clientId = decoded.clientId;
 
             // Guardamos el clientId si existe
@@ -39,9 +41,9 @@ function LoginPage() {
             }
 
             // Redirigimos según el rol del usuario
-            if (roles.includes('ROLE_ADMIN')) {
+            if (role === 'ADMIN') {
                 navigate('/panel-admin');
-            } else if (roles.includes('ROLE_CLIENT')) {
+            } else if (role === 'CASHIER' || role === 'ADMIN') {
                 navigate('/panel-cliente');
             } else {
                 setError('Su cuenta no tiene un rol válido.');


### PR DESCRIPTION
## Summary
- rename `Client` entity to `Employee` and add `Role` enum
- update repositories, services and controllers for employees
- secure client routes for `ADMIN`/`CASHIER` roles
- expose new `/client/employees` endpoints
- show employees section in client panel

## Testing
- `gestion-inventario-backend/mvnw -q test` *(fails: Non-resolvable parent POM)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68463a3650e4832bb4e8a4f082331758