### PR TITLE
Implement basic sale return feature

### DIFF
--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/dto/SaleReturnItemRequest.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/dto/SaleReturnItemRequest.java
@@ -1,0 +1,16 @@
+package grupo5.gestion_inventario.clientpanel.dto;
+
+import java.math.BigDecimal;
+
+public class SaleReturnItemRequest {
+    private Long productId;
+    private int quantity;
+    private BigDecimal unitPrice;
+
+    public Long getProductId() { return productId; }
+    public void setProductId(Long productId) { this.productId = productId; }
+    public int getQuantity() { return quantity; }
+    public void setQuantity(int quantity) { this.quantity = quantity; }
+    public BigDecimal getUnitPrice() { return unitPrice; }
+    public void setUnitPrice(BigDecimal unitPrice) { this.unitPrice = unitPrice; }
+}

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/dto/SaleReturnRequest.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/dto/SaleReturnRequest.java
@@ -1,0 +1,13 @@
+package grupo5.gestion_inventario.clientpanel.dto;
+
+import java.util.List;
+
+public class SaleReturnRequest {
+    private Long saleId;
+    private List<SaleReturnItemRequest> items;
+
+    public Long getSaleId() { return saleId; }
+    public void setSaleId(Long saleId) { this.saleId = saleId; }
+    public List<SaleReturnItemRequest> getItems() { return items; }
+    public void setItems(List<SaleReturnItemRequest> items) { this.items = items; }
+}

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/model/SaleReturn.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/model/SaleReturn.java
@@ -1,0 +1,48 @@
+package grupo5.gestion_inventario.clientpanel.model;
+
+import com.fasterxml.jackson.annotation.JsonManagedReference;
+import grupo5.gestion_inventario.model.BusinessAccount;
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "sale_return")
+public class SaleReturn {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "business_account_id", nullable = false)
+    private BusinessAccount businessAccount;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sale_id")
+    private Sale sale;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @OneToMany(mappedBy = "saleReturn", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonManagedReference
+    private List<SaleReturnItem> items = new ArrayList<>();
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    // Getters and setters
+    public Long getId() { return id; }
+    public BusinessAccount getBusinessAccount() { return businessAccount; }
+    public void setBusinessAccount(BusinessAccount businessAccount) { this.businessAccount = businessAccount; }
+    public Sale getSale() { return sale; }
+    public void setSale(Sale sale) { this.sale = sale; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
+    public List<SaleReturnItem> getItems() { return items; }
+    public void setItems(List<SaleReturnItem> items) { this.items = items; }
+}

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/model/SaleReturnItem.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/model/SaleReturnItem.java
@@ -1,0 +1,40 @@
+package grupo5.gestion_inventario.clientpanel.model;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import grupo5.gestion_inventario.model.Product;
+import jakarta.persistence.*;
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "sale_return_item")
+public class SaleReturnItem {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sale_return_id", nullable = false)
+    @JsonBackReference
+    private SaleReturn saleReturn;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    @Column(nullable = false)
+    private int quantity;
+
+    @Column(nullable = false, precision = 19, scale = 2)
+    private BigDecimal unitPrice;
+
+    // Getters and setters
+    public Long getId() { return id; }
+    public SaleReturn getSaleReturn() { return saleReturn; }
+    public void setSaleReturn(SaleReturn saleReturn) { this.saleReturn = saleReturn; }
+    public Product getProduct() { return product; }
+    public void setProduct(Product product) { this.product = product; }
+    public int getQuantity() { return quantity; }
+    public void setQuantity(int quantity) { this.quantity = quantity; }
+    public BigDecimal getUnitPrice() { return unitPrice; }
+    public void setUnitPrice(BigDecimal unitPrice) { this.unitPrice = unitPrice; }
+}

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/repository/SaleReturnRepository.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/repository/SaleReturnRepository.java
@@ -1,0 +1,12 @@
+package grupo5.gestion_inventario.clientpanel.repository;
+
+import grupo5.gestion_inventario.clientpanel.model.SaleReturn;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface SaleReturnRepository extends JpaRepository<SaleReturn, Long> {
+    List<SaleReturn> findByBusinessAccountId(Long businessAccountId);
+}

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/controller/ClientSaleReturnController.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/controller/ClientSaleReturnController.java
@@ -1,0 +1,48 @@
+package grupo5.gestion_inventario.controller;
+
+import grupo5.gestion_inventario.clientpanel.dto.SaleReturnRequest;
+import grupo5.gestion_inventario.clientpanel.model.SaleReturn;
+import grupo5.gestion_inventario.clientpanel.repository.SaleReturnRepository;
+import grupo5.gestion_inventario.repository.BusinessAccountRepository;
+import grupo5.gestion_inventario.service.SaleReturnService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/client/sale-returns")
+public class ClientSaleReturnController {
+
+    private final SaleReturnService saleReturnService;
+    private final BusinessAccountRepository businessAccountRepo;
+
+    public ClientSaleReturnController(SaleReturnService saleReturnService,
+                                      BusinessAccountRepository businessAccountRepo) {
+        this.saleReturnService = saleReturnService;
+        this.businessAccountRepo = businessAccountRepo;
+    }
+
+    @PostMapping
+    @PreAuthorize("hasAnyAuthority('MANAGER','CASHIER')")
+    public ResponseEntity<SaleReturn> createReturn(@RequestBody SaleReturnRequest request,
+                                                   Authentication auth) {
+        Long clientId = businessAccountRepo.findByEmail(auth.getName())
+                .orElseThrow(() -> new IllegalArgumentException("Cliente no encontrado"))
+                .getId();
+        SaleReturn created = saleReturnService.createReturn(clientId, request);
+        return ResponseEntity.status(201).body(created);
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAnyAuthority('MANAGER','CASHIER')")
+    public ResponseEntity<List<SaleReturn>> list(Authentication auth) {
+        Long clientId = businessAccountRepo.findByEmail(auth.getName())
+                .orElseThrow(() -> new IllegalArgumentException("Cliente no encontrado"))
+                .getId();
+        List<SaleReturn> returns = saleReturnService.findByClientId(clientId);
+        return ResponseEntity.ok(returns);
+    }
+}

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/service/SaleReturnService.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/service/SaleReturnService.java
@@ -1,0 +1,85 @@
+package grupo5.gestion_inventario.service;
+
+import grupo5.gestion_inventario.clientpanel.dto.SaleReturnItemRequest;
+import grupo5.gestion_inventario.clientpanel.dto.SaleReturnRequest;
+import grupo5.gestion_inventario.clientpanel.model.Sale;
+import grupo5.gestion_inventario.clientpanel.model.SaleReturn;
+import grupo5.gestion_inventario.clientpanel.model.SaleReturnItem;
+import grupo5.gestion_inventario.clientpanel.model.StockMovement;
+import grupo5.gestion_inventario.clientpanel.repository.SaleRepository;
+import grupo5.gestion_inventario.clientpanel.repository.SaleReturnRepository;
+import grupo5.gestion_inventario.clientpanel.repository.StockMovementRepository;
+import grupo5.gestion_inventario.model.BusinessAccount;
+import grupo5.gestion_inventario.model.Product;
+import grupo5.gestion_inventario.repository.BusinessAccountRepository;
+import grupo5.gestion_inventario.repository.ProductRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Service
+public class SaleReturnService {
+    private final SaleReturnRepository saleReturnRepo;
+    private final BusinessAccountRepository businessAccountRepo;
+    private final SaleRepository saleRepo;
+    private final ProductRepository productRepo;
+    private final StockMovementRepository stockMovementRepo;
+
+    public SaleReturnService(SaleReturnRepository saleReturnRepo,
+                             BusinessAccountRepository businessAccountRepo,
+                             SaleRepository saleRepo,
+                             ProductRepository productRepo,
+                             StockMovementRepository stockMovementRepo) {
+        this.saleReturnRepo = saleReturnRepo;
+        this.businessAccountRepo = businessAccountRepo;
+        this.saleRepo = saleRepo;
+        this.productRepo = productRepo;
+        this.stockMovementRepo = stockMovementRepo;
+    }
+
+    @Transactional
+    public SaleReturn createReturn(Long clientId, SaleReturnRequest req) {
+        BusinessAccount account = businessAccountRepo.findById(clientId)
+                .orElseThrow(() -> new IllegalArgumentException("BusinessAccount no encontrado: " + clientId));
+
+        Sale sale = null;
+        if (req.getSaleId() != null) {
+            sale = saleRepo.findById(req.getSaleId())
+                    .orElseThrow(() -> new IllegalArgumentException("Venta no encontrada: " + req.getSaleId()));
+        }
+
+        SaleReturn saleReturn = new SaleReturn();
+        saleReturn.setBusinessAccount(account);
+        saleReturn.setSale(sale);
+
+        for (SaleReturnItemRequest itemReq : req.getItems()) {
+            Product product = productRepo.findById(itemReq.getProductId())
+                    .orElseThrow(() -> new IllegalArgumentException("Producto no encontrado (ID): " + itemReq.getProductId()));
+
+            product.setStockQuantity(product.getStockQuantity() + itemReq.getQuantity());
+
+            SaleReturnItem item = new SaleReturnItem();
+            item.setSaleReturn(saleReturn);
+            item.setProduct(product);
+            item.setQuantity(itemReq.getQuantity());
+            item.setUnitPrice(itemReq.getUnitPrice() != null ? itemReq.getUnitPrice() : BigDecimal.ZERO);
+            saleReturn.getItems().add(item);
+
+            StockMovement m = new StockMovement();
+            m.setProduct(product);
+            m.setQuantityChange(itemReq.getQuantity());
+            m.setType(StockMovement.StockMovementType.RETURN);
+            m.setRelatedSaleId(req.getSaleId());
+            stockMovementRepo.save(m);
+        }
+
+        return saleReturnRepo.save(saleReturn);
+    }
+
+    @Transactional(readOnly = true)
+    public List<SaleReturn> findByClientId(Long clientId) {
+        return saleReturnRepo.findByBusinessAccountId(clientId);
+    }
+}

--- a/gestion-inventario-frontend/src/App.jsx
+++ b/gestion-inventario-frontend/src/App.jsx
@@ -4,6 +4,7 @@ import ProtectedRoute from './components/ProtectedRoute';
 import ClientPanelPage from './pages/ClientPanelPage';
 import ArticleFormPage from './pages/ArticleFormPage';
 import SaleFormPage from './pages/SaleFormPage';
+import SaleReturnFormPage from './pages/SaleReturnFormPage';
 import ProviderFormPage from './pages/ProviderFormPage';
 import AdminPanelPage from './pages/AdminPanelPage';
 import ClientFormPage from "./pages/ClientFormPage.jsx"; // <-- IMPORTAMOS
@@ -22,6 +23,7 @@ function App() {
             <Route path="/form-articulo" element={<ProtectedRoute><ArticleFormPage /></ProtectedRoute>} />
             <Route path="/form-articulo/:productId" element={<ProtectedRoute><ArticleFormPage /></ProtectedRoute>} />
             <Route path="/form-venta" element={<ProtectedRoute><SaleFormPage /></ProtectedRoute>} />
+            <Route path="/form-devolucion" element={<ProtectedRoute><SaleReturnFormPage /></ProtectedRoute>} />
             <Route path="/form-proveedor" element={<ProtectedRoute><ProviderFormPage /></ProtectedRoute>} />
             <Route path="/form-proveedor/:providerId" element={<ProtectedRoute><ProviderFormPage /></ProtectedRoute>} />
             {/* --- NUEVA RUTA PARA EL FORMULARIO DE CLIENTE --- */}

--- a/gestion-inventario-frontend/src/components/client/SalesSection.jsx
+++ b/gestion-inventario-frontend/src/components/client/SalesSection.jsx
@@ -29,6 +29,10 @@ function SalesSection() {
         navigate('/form-venta'); // Iremos a esta ruta en el siguiente paso
     };
 
+    const handleNewReturn = () => {
+        navigate('/form-devolucion');
+    };
+
     if (loading) {
         return <div>Cargando ventas...</div>;
     }
@@ -41,7 +45,10 @@ function SalesSection() {
         <div className="sales-section">
             <div className="section-header">
                 <h2>Ventas</h2>
-                <button className="btn-new" onClick={handleNewSale}>Registrar nueva venta</button>
+                <div>
+                    <button className="btn-new" onClick={handleNewSale}>Registrar nueva venta</button>
+                    <button className="btn-new" onClick={handleNewReturn}>Registrar devolución</button>
+                </div>
             </div>
             <table>
                 <thead>

--- a/gestion-inventario-frontend/src/pages/SaleReturnFormPage.jsx
+++ b/gestion-inventario-frontend/src/pages/SaleReturnFormPage.jsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { api } from '../services/api';
+import './SaleFormPage.css';
+
+function SaleReturnFormPage() {
+    const navigate = useNavigate();
+    const [articles, setArticles] = useState([]);
+    const [selectedArticleId, setSelectedArticleId] = useState('');
+    const [quantity, setQuantity] = useState(1);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState('');
+
+    useEffect(() => {
+        api.get('/client/items')
+            .then(data => setArticles(data))
+            .catch(err => setError(err.message || 'No se pudieron cargar los productos'))
+            .finally(() => setLoading(false));
+    }, []);
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        setError('');
+        const article = articles.find(a => a.id === parseInt(selectedArticleId, 10));
+        if (!article) {
+            setError('Debes seleccionar un producto');
+            return;
+        }
+        const payload = {
+            items: [
+                {
+                    productId: article.id,
+                    quantity: parseInt(quantity, 10),
+                    unitPrice: article.price
+                }
+            ]
+        };
+        try {
+            await api.post('/client/sale-returns', payload);
+            alert('Devolución registrada');
+            navigate('/panel-cliente#ventas');
+        } catch (err) {
+            setError(err.message || 'Error al registrar la devolución');
+        }
+    };
+
+    if (loading) {
+        return <div>Cargando...</div>;
+    }
+
+    return (
+        <div className="container-form">
+            <header className="form-header">
+                <h1>Registrar Devolución</h1>
+            </header>
+            <main>
+                <form id="form-venta" onSubmit={handleSubmit}>
+                    <div className="form-group">
+                        <label htmlFor="articulo">Artículo:</label>
+                        <select id="articulo" value={selectedArticleId} onChange={e => setSelectedArticleId(e.target.value)} required>
+                            <option value="">Seleccione...</option>
+                            {articles.map(a => (
+                                <option key={a.id} value={a.id}>{a.name}</option>
+                            ))}
+                        </select>
+                    </div>
+                    <div className="form-group">
+                        <label htmlFor="cantidad">Cantidad:</label>
+                        <input type="number" id="cantidad" min="1" value={quantity} onChange={e => setQuantity(e.target.value)} required />
+                    </div>
+                    {error && <p className="error-message">{error}</p>}
+                    <div className="form-actions">
+                        <button type="submit" className="btn-submit">Registrar</button>
+                        <button type="button" className="btn-cancel" onClick={() => navigate('/panel-cliente#ventas')}>Cancelar</button>
+                    </div>
+                </form>
+            </main>
+        </div>
+    );
+}
+
+export default SaleReturnFormPage;


### PR DESCRIPTION
## Summary
- add `SaleReturn` and `SaleReturnItem` entities
- create controller, service and repository to handle returns
- expose new client endpoint to register and list sale returns
- add return form page and route in the React frontend
- allow registering a return from the sales section

## Testing
- `mvn test` *(fails: mvn not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68464fc95b14832ba6fb71026f0a80ff