### PR TITLE
Add tax and discount support

### DIFF
--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/dto/PurchaseOrderItemRequest.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/dto/PurchaseOrderItemRequest.java
@@ -8,6 +8,9 @@ public class PurchaseOrderItemRequest {
     private int quantity;
     private BigDecimal cost;
 
+    private BigDecimal tax;
+    private BigDecimal discount;
+
     // Getters y Setters
 
     public Long getProductId() {
@@ -32,5 +35,21 @@ public class PurchaseOrderItemRequest {
 
     public void setCost(BigDecimal cost) {
         this.cost = cost;
+    }
+
+    public BigDecimal getTax() {
+        return tax;
+    }
+
+    public void setTax(BigDecimal tax) {
+        this.tax = tax;
+    }
+
+    public BigDecimal getDiscount() {
+        return discount;
+    }
+
+    public void setDiscount(BigDecimal discount) {
+        this.discount = discount;
     }
 }

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/dto/SaleItemRequest.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/dto/SaleItemRequest.java
@@ -16,6 +16,12 @@ public class SaleItemRequest {
     /** Precio unitario */
     private BigDecimal unitPrice;
 
+    /** Impuesto aplicado */
+    private BigDecimal tax;
+
+    /** Descuento aplicado */
+    private BigDecimal discount;
+
     public SaleItemRequest() { }
 
     public Long getProductId() {
@@ -40,5 +46,21 @@ public class SaleItemRequest {
 
     public void setUnitPrice(BigDecimal unitPrice) {
         this.unitPrice = unitPrice;
+    }
+
+    public BigDecimal getTax() {
+        return tax;
+    }
+
+    public void setTax(BigDecimal tax) {
+        this.tax = tax;
+    }
+
+    public BigDecimal getDiscount() {
+        return discount;
+    }
+
+    public void setDiscount(BigDecimal discount) {
+        this.discount = discount;
     }
 }

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/model/Sale.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/model/Sale.java
@@ -105,6 +105,8 @@ public class Sale {
         items.add(item);
         totalAmount = totalAmount.add(
                 item.getUnitPrice().multiply(BigDecimal.valueOf(item.getQuantity()))
+                        .add(item.getTax())
+                        .subtract(item.getDiscount())
         );
     }
 
@@ -113,6 +115,8 @@ public class Sale {
         for (SaleItem item : items) {
             totalAmount = totalAmount.add(
                     item.getUnitPrice().multiply(BigDecimal.valueOf(item.getQuantity()))
+                            .add(item.getTax())
+                            .subtract(item.getDiscount())
             );
         }
     }

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/model/SaleItem.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/clientpanel/model/SaleItem.java
@@ -31,6 +31,14 @@ public class SaleItem {
     @Column(nullable = false, precision = 19, scale = 2)
     private BigDecimal unitPrice;
 
+    /** Impuesto aplicado al ítem */
+    @Column(nullable = false, precision = 19, scale = 2)
+    private BigDecimal tax = BigDecimal.ZERO;
+
+    /** Descuento aplicado al ítem */
+    @Column(nullable = false, precision = 19, scale = 2)
+    private BigDecimal discount = BigDecimal.ZERO;
+
     /** Constructor por defecto */
     public SaleItem() {}
 
@@ -40,10 +48,13 @@ public class SaleItem {
      * @param quantity  Cantidad vendida
      * @param unitPrice Precio unitario
      */
-    public SaleItem(Product product, Integer quantity, BigDecimal unitPrice) {
+    public SaleItem(Product product, Integer quantity, BigDecimal unitPrice,
+                    BigDecimal tax, BigDecimal discount) {
         this.product   = product;
         this.quantity  = quantity;
         this.unitPrice = unitPrice;
+        this.tax       = tax != null ? tax : BigDecimal.ZERO;
+        this.discount  = discount != null ? discount : BigDecimal.ZERO;
     }
 
     // —— Getters & Setters ——
@@ -78,6 +89,20 @@ public class SaleItem {
     }
     public void setUnitPrice(BigDecimal unitPrice) {
         this.unitPrice = unitPrice;
+    }
+
+    public BigDecimal getTax() {
+        return tax;
+    }
+    public void setTax(BigDecimal tax) {
+        this.tax = tax;
+    }
+
+    public BigDecimal getDiscount() {
+        return discount;
+    }
+    public void setDiscount(BigDecimal discount) {
+        this.discount = discount;
     }
 }
 

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/model/PurchaseOrderItem.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/model/PurchaseOrderItem.java
@@ -28,6 +28,12 @@ public class PurchaseOrderItem {
     @Column(nullable = false)
     private BigDecimal cost;
 
+    @Column(nullable = false, precision = 19, scale = 2)
+    private BigDecimal tax = BigDecimal.ZERO;
+
+    @Column(nullable = false, precision = 19, scale = 2)
+    private BigDecimal discount = BigDecimal.ZERO;
+
     // Getters y Setters
 
     public Long getId() {
@@ -68,5 +74,21 @@ public class PurchaseOrderItem {
 
     public void setCost(BigDecimal cost) {
         this.cost = cost;
+    }
+
+    public BigDecimal getTax() {
+        return tax;
+    }
+
+    public void setTax(BigDecimal tax) {
+        this.tax = tax;
+    }
+
+    public BigDecimal getDiscount() {
+        return discount;
+    }
+
+    public void setDiscount(BigDecimal discount) {
+        this.discount = discount;
     }
 }

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/service/PurchaseOrderService.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/service/PurchaseOrderService.java
@@ -77,10 +77,16 @@ public class PurchaseOrderService {
             item.setProduct(product);
             item.setQuantity(itemRequest.getQuantity());
             item.setCost(itemRequest.getCost());
+            item.setTax(itemRequest.getTax());
+            item.setDiscount(itemRequest.getDiscount());
             item.setPurchaseOrder(purchaseOrder); // Establecer la relación bidireccional
 
             items.add(item);
-            totalCost = totalCost.add(item.getCost().multiply(BigDecimal.valueOf(item.getQuantity())));
+            totalCost = totalCost.add(
+                    item.getCost().multiply(BigDecimal.valueOf(item.getQuantity()))
+                            .add(item.getTax())
+                            .subtract(item.getDiscount())
+            );
         }
 
         // 4. Asignar los valores finales y guardar

--- a/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/service/SalesService.java
+++ b/gestion-inventario-backend/src/main/java/grupo5/gestion_inventario/service/SalesService.java
@@ -74,7 +74,13 @@ public class SalesService {
             }
             product.setStockQuantity(newStock);
 
-            SaleItem item = new SaleItem(product, itemRequest.getQuantity(), itemRequest.getUnitPrice());
+            SaleItem item = new SaleItem(
+                    product,
+                    itemRequest.getQuantity(),
+                    itemRequest.getUnitPrice(),
+                    itemRequest.getTax(),
+                    itemRequest.getDiscount()
+            );
             sale.addItem(item);
         });
 

--- a/gestion-inventario-frontend/src/pages/PurchaseOrderFormPage.jsx
+++ b/gestion-inventario-frontend/src/pages/PurchaseOrderFormPage.jsx
@@ -9,7 +9,7 @@ function PurchaseOrderFormPage() {
     const [providers, setProviders] = useState([]);
     const [products, setProducts] = useState([]);
     const [items, setItems] = useState([
-        { productId: '', quantity: 1, cost: 0 }
+        { productId: '', quantity: 1, cost: 0, tax: 0, discount: 0 }
     ]);
     const [providerId, setProviderId] = useState('');
     const [loading, setLoading] = useState(true);
@@ -38,7 +38,7 @@ function PurchaseOrderFormPage() {
     };
 
     const addItem = () => {
-        setItems(prev => [...prev, { productId: '', quantity: 1, cost: 0 }]);
+        setItems(prev => [...prev, { productId: '', quantity: 1, cost: 0, tax: 0, discount: 0 }]);
     };
 
     const removeItem = (index) => {
@@ -55,7 +55,9 @@ function PurchaseOrderFormPage() {
             items: items.map(it => ({
                 productId: parseInt(it.productId, 10),
                 quantity: parseInt(it.quantity, 10),
-                cost: parseFloat(it.cost)
+                cost: parseFloat(it.cost),
+                tax: parseFloat(it.tax),
+                discount: parseFloat(it.discount)
             }))
         };
         try {
@@ -98,6 +100,8 @@ function PurchaseOrderFormPage() {
                             </select>
                             <input type="number" min="1" value={item.quantity} onChange={e => handleItemChange(idx, 'quantity', e.target.value)} />
                             <input type="number" min="0" step="0.01" value={item.cost} onChange={e => handleItemChange(idx, 'cost', e.target.value)} />
+                            <input type="number" min="0" step="0.01" value={item.tax} onChange={e => handleItemChange(idx, 'tax', e.target.value)} placeholder="IVA" />
+                            <input type="number" min="0" step="0.01" value={item.discount} onChange={e => handleItemChange(idx, 'discount', e.target.value)} placeholder="Descuento" />
                             {items.length > 1 && <button type="button" className="btn-delete" onClick={() => removeItem(idx)}>Eliminar</button>}
                         </div>
                     ))}

--- a/gestion-inventario-frontend/src/pages/SaleFormPage.jsx
+++ b/gestion-inventario-frontend/src/pages/SaleFormPage.jsx
@@ -12,6 +12,8 @@ function SaleFormPage() {
     const [customers, setCustomers] = useState([]);
     const [selectedCustomerId, setSelectedCustomerId] = useState('');
     const [quantity, setQuantity] = useState(1);
+    const [tax, setTax] = useState(0);
+    const [discount, setDiscount] = useState(0);
     const [paymentMethod, setPaymentMethod] = useState('');
     const [saleDate, setSaleDate] = useState('');
 
@@ -58,6 +60,8 @@ function SaleFormPage() {
                     productId: selectedArticle.id,
                     quantity: parseInt(quantity, 10),
                     unitPrice: selectedArticle.price,
+                    tax: parseFloat(tax),
+                    discount: parseFloat(discount),
                 },
             ],
         };
@@ -107,6 +111,16 @@ function SaleFormPage() {
                     <div className="form-group">
                         <label htmlFor="cantidad">Cantidad:</label>
                         <input type="number" id="cantidad" name="cantidad" min="1" required value={quantity} onChange={e => setQuantity(e.target.value)} />
+                    </div>
+
+                    <div className="form-group">
+                        <label htmlFor="tax">IVA:</label>
+                        <input type="number" id="tax" step="0.01" min="0" value={tax} onChange={e => setTax(e.target.value)} />
+                    </div>
+
+                    <div className="form-group">
+                        <label htmlFor="discount">Descuento:</label>
+                        <input type="number" id="discount" step="0.01" min="0" value={discount} onChange={e => setDiscount(e.target.value)} />
                     </div>
 
                     <div className="form-group">


### PR DESCRIPTION
## Summary
- allow tracking tax and discount on sale items
- include tax/discount on purchase items
- compute totals with tax and discounts on backend services
- capture tax/discount on purchase and sale forms

## Testing
- `npm run lint`
- `mvn test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68465164335c832b85fbd633cff962e9