### PR TITLE
Remove DB credentials

### DIFF
--- a/gestion-inventario-backend/README.md
+++ b/gestion-inventario-backend/README.md
@@ -1,0 +1,8 @@
+# Backend Setup
+
+This Spring Boot application requires environment variables for the database connection. Configure the following variables before running the project:
+
+- `SPRING_DATASOURCE_USERNAME` – Database user
+- `SPRING_DATASOURCE_PASSWORD` – Database password
+
+Spring Boot will automatically use these variables if they are set in the environment.

--- a/gestion-inventario-backend/src/main/resources/application.properties
+++ b/gestion-inventario-backend/src/main/resources/application.properties
@@ -1,7 +1,5 @@
 # Configuracion de conexion a MySQL
 spring.datasource.url=jdbc:mysql://localhost:3307/gestionBaseDatos?useSSL=false&serverTimezone=UTC
-spring.datasource.username=root
-spring.datasource.password=
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # JPA y Hibernate


### PR DESCRIPTION
## Summary
- remove hardcoded DB credentials from application properties
- add backend README mentioning required environment variables

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684654f7ab64832ba16c6d5f16d1dda9